### PR TITLE
DOE-2898: Tagging

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,7 @@ node ('tpt2-slave'){
       ]), pipelineTriggers([pollSCM('H/5 * * * *')])])
   try {
    stage('Preparation') {
-		  git branch: '$branch', url: 'https://github.com/ca-cwds/geo-services-api.git'
+		  git branch: '$branch', credentialsId: '433ac100-b3c2-4519-b4d6-207c029a103b', url: 'git@github.com:ca-cwds/geo-services-api.git'
 		  rtGradle.tool = "Gradle_35"
 		  rtGradle.resolver repo:'repo', server: serverArti
 		  rtGradle.useWrapper = true

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -38,10 +38,16 @@ node ('tpt2-slave'){
 	}
 	stage ('Build Docker'){
 	   buildInfo = rtGradle.run buildFile: 'build.gradle', tasks: 'createDockerImage -DRelease=$RELEASE_PROJECT -DBuildNumber=$BUILD_NUMBER -DCustomVersion=$OVERRIDE_VERSION'
+	}
+    stage('Tag Git') {
+        // tagRepo('test-tags')
+	   def buildInfo = rtGradle.run buildFile: 'build.gradle', tasks: 'pushGitTag -DRelease=$RELEASE_PROJECT -DBuildNumber=$BUILD_NUMBER -DCustomVersion=$OVERRIDE_VERSION'
+    }
+    stage('Push to Docker Image') {
 	   withDockerRegistry([credentialsId: '6ba8d05c-ca13-4818-8329-15d41a089ec0']) {
            buildInfo = rtGradle.run buildFile: 'build.gradle', tasks: 'publishDocker -DRelease=$RELEASE_PROJECT -DBuildNumber=$BUILD_NUMBER -DCustomVersion=$OVERRIDE_VERSION'
        }
-	}
+    }
 	stage('Clean Workspace') {
 		buildInfo = rtGradle.run buildFile: 'build.gradle', tasks: 'dropDockerImage -DRelease=$RELEASE_PROJECT -DBuildNumber=$BUILD_NUMBER -DCustomVersion=$OVERRIDE_VERSION'
 		archiveArtifacts artifacts: '**/geo-services-api-*.jar,readme.txt', fingerprint: true

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -30,12 +30,6 @@ node ('tpt2-slave'){
 			buildInfo = rtGradle.run buildFile: 'build.gradle', switches: '--info', tasks: 'sonarqube'
         }
     }
-
-	stage ('Push to artifactory'){
-	    rtGradle.deployer.deployArtifacts = true
-	    buildInfo = rtGradle.run buildFile: 'build.gradle', tasks: 'publish -DRelease=$RELEASE_PROJECT -DBuildNumber=$BUILD_NUMBER -DCustomVersion=$OVERRIDE_VERSION'
-  		rtGradle.deployer.deployArtifacts = false
-	}
 	stage ('Build Docker'){
 	   buildInfo = rtGradle.run buildFile: 'build.gradle', tasks: 'createDockerImage -DRelease=$RELEASE_PROJECT -DBuildNumber=$BUILD_NUMBER -DCustomVersion=$OVERRIDE_VERSION'
 	}
@@ -43,6 +37,11 @@ node ('tpt2-slave'){
         // tagRepo('test-tags')
 	   def buildInfo = rtGradle.run buildFile: 'build.gradle', tasks: 'pushGitTag -DRelease=$RELEASE_PROJECT -DBuildNumber=$BUILD_NUMBER -DCustomVersion=$OVERRIDE_VERSION'
     }
+    stage ('Push to artifactory'){
+	    rtGradle.deployer.deployArtifacts = true
+	    buildInfo = rtGradle.run buildFile: 'build.gradle', tasks: 'publish -DRelease=$RELEASE_PROJECT -DBuildNumber=$BUILD_NUMBER -DCustomVersion=$OVERRIDE_VERSION'
+  		rtGradle.deployer.deployArtifacts = false
+	}
     stage('Push to Docker Image') {
 	   withDockerRegistry([credentialsId: '6ba8d05c-ca13-4818-8329-15d41a089ec0']) {
            buildInfo = rtGradle.run buildFile: 'build.gradle', tasks: 'publishDocker -DRelease=$RELEASE_PROJECT -DBuildNumber=$BUILD_NUMBER -DCustomVersion=$OVERRIDE_VERSION'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -30,6 +30,12 @@ node ('tpt2-slave'){
 			buildInfo = rtGradle.run buildFile: 'build.gradle', switches: '--info', tasks: 'sonarqube'
         }
     }
+
+	stage ('Push to artifactory'){
+	    rtGradle.deployer.deployArtifacts = true
+	    buildInfo = rtGradle.run buildFile: 'build.gradle', tasks: 'publish -DRelease=$RELEASE_PROJECT -DBuildNumber=$BUILD_NUMBER -DCustomVersion=$OVERRIDE_VERSION'
+  		rtGradle.deployer.deployArtifacts = false
+	}
 	stage ('Build Docker'){
 	   buildInfo = rtGradle.run buildFile: 'build.gradle', tasks: 'createDockerImage -DRelease=$RELEASE_PROJECT -DBuildNumber=$BUILD_NUMBER -DCustomVersion=$OVERRIDE_VERSION'
 	}
@@ -37,11 +43,6 @@ node ('tpt2-slave'){
         // tagRepo('test-tags')
 	   def buildInfo = rtGradle.run buildFile: 'build.gradle', tasks: 'pushGitTag -DRelease=$RELEASE_PROJECT -DBuildNumber=$BUILD_NUMBER -DCustomVersion=$OVERRIDE_VERSION'
     }
-    stage ('Push to artifactory'){
-	    rtGradle.deployer.deployArtifacts = true
-	    buildInfo = rtGradle.run buildFile: 'build.gradle', tasks: 'publish -DRelease=$RELEASE_PROJECT -DBuildNumber=$BUILD_NUMBER -DCustomVersion=$OVERRIDE_VERSION'
-  		rtGradle.deployer.deployArtifacts = false
-	}
     stage('Push to Docker Image') {
 	   withDockerRegistry([credentialsId: '6ba8d05c-ca13-4818-8329-15d41a089ec0']) {
            buildInfo = rtGradle.run buildFile: 'build.gradle', tasks: 'publishDocker -DRelease=$RELEASE_PROJECT -DBuildNumber=$BUILD_NUMBER -DCustomVersion=$OVERRIDE_VERSION'

--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ project.ext {
     buildNumber = System.getProperty('BuildNumber')
     customVersion = System.getProperty('CustomVersion')
 
-    projectSnapshotVersion = "${projectMajorVersion}_${buildNumber}-SNAPSHOT"
+    projectSnapshotVersion = projectMajorVersion + "-SNAPSHOT"
     projectReleaseVersion = (customVersion == null || customVersion == "" || customVersion.startsWith('$') ? projectMajorVersion + '_' + buildNumber + '-RC' : customVersion )
     projectVersion = (isRelease ? projectReleaseVersion : projectSnapshotVersion )
     dockerTag = projectVersion

--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ project.ext {
     buildNumber = System.getProperty('BuildNumber')
     customVersion = System.getProperty('CustomVersion')
 
-    projectSnapshotVersion = projectMajorVersion + "-SNAPSHOT"
+    projectSnapshotVersion = "${projectMajorVersion}_${buildNumber}-SNAPSHOT"
     projectReleaseVersion = (customVersion == null || customVersion == "" || customVersion.startsWith('$') ? projectMajorVersion + '_' + buildNumber + '-RC' : customVersion )
     projectVersion = (isRelease ? projectReleaseVersion : projectSnapshotVersion )
     dockerTag = projectVersion

--- a/build.gradle
+++ b/build.gradle
@@ -234,6 +234,22 @@ task publishDocker(dependsOn: [pushDockerVersionTagged, pushDockerLatest]) {
     }
 }
 
+task createGitTag(type:Exec) {
+    commandLine "git", "tag", "$dockerTag"
+}
+
+task pushGitTag(type:Exec, dependsOn: createGitTag) {
+    doFirst{
+        environment "GIT_SSH_COMMAND", 'ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no'
+    }
+    
+    commandLine "git", "push", "origin", "$dockerTag"
+    
+    doLast {
+        println "Pushed tagged to Git origin"
+    }
+}
+
 processResources {
     filter(ReplaceTokens, tokens:[
             'build.version' : projectVersion,


### PR DESCRIPTION
@jimb2850 and @ashishkumarcwds are driving this process, but was helping out on east coast hours and thing it's ready -- so submitting. Questions can go their way though.

The change to the build and Jenkins pipeline adds a stage to tag the Git repository with the version used in the Docker and Artifactory pushes. 

The DevOps team was initially going to implement this with [SemVer/tag-prototype](https://github.com/ca-cwds/tag-prototype/), but the product owner for the team opted to do full automation at a later point in the future, so this is just a patch to use the existing version numbers as Git tags. Note that this does require changes to the code base to modify the `projectMajorVersion` setting in `build.gradle` in order to avoid tag collisions (i.e. the build will fail if the Git tag already exists).

While working on this, we encountered a few problems that pre-existed with the build and we did not fix do to time constraints. They should be addresses in the future and include:

- The automatic build does not start successfully following a change to master. Past Jenkins logs revealed this to be a problem before work on tagging began. Issue seems to be around the `OVERRIDE_VERSION` environment variable. We weren't able to identify a quick fix.
- Related to the above. Manual kickoffs of the Jenkins build do not experience the same problem and we suspect that's how the team was producing and deploying new build artifacts.
- Testing succeeded see 
[see geo-services-api-build #124 Console [Jenkins].pdf](https://github.com/ca-cwds/geo-services-api/files/2098795/geo-services-api-build.124.Console.Jenkins.pdf), but then unit test issues occurred afterwards, but do not seem related to the work done on tagging (i.e. it doesn't even get to the modified areas of the build). Is it possible that a dependent system outside this codebase is impacting this job's ability to run? If so, it's recommended that the unit tests use mocks instead of live servers. If not, then it probably also requires intervention from the dev team to fix. Which Jira project + Jira team should we file an issue for?
- Unit tests are not currently run w/ Jenkins during the pull request process (just Code Climate). It's recommended to run the unit tests at PR time.